### PR TITLE
Set an away (always False) property on the MUC class

### DIFF
--- a/jabber.py
+++ b/jabber.py
@@ -1160,6 +1160,7 @@ class MUC:
         self.domain = ''
         self.resource = ''
         self.alias = ''
+        self.away = False
         self.buddies = []
         self.parse_jid()
         self.set_alias()


### PR DESCRIPTION
This allows aliases to be set for MUC-related JIDs. Without it,
attempting to do so causes a crash.
